### PR TITLE
Fix sending mail with Thunderbird on MacOS

### DIFF
--- a/electron/mail.js
+++ b/electron/mail.js
@@ -83,7 +83,7 @@ function detectMailClientsMacOS(candidates) {
       exec(`find /Applications -maxdepth 2 -type d -name '${name}'`).split('\n')[0];
 
     if (findResult !== '') {
-      result[name] = {  path: findResult, description };
+      result[name] = {  path: `${findResult}/Contents/MacOS/${binary}`, description };
     }
 
     return result;


### PR DESCRIPTION
Previously it tried to execute `/Application/Thunderbird.app`, which isn't an application. It still fails when Thunderbird is already open.